### PR TITLE
Added agros link private limited in footer

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -16,6 +16,7 @@ const About = () => {
                 With a deep understanding of the challenges faced by farmers and a commitment to innovation, we strive to 
                 create solutions that make farming more efficient, sustainable, and profitable.
               </p>
+              <p>COI:U01110TG2022PTC160565</p>
             </div>
 
             {/* Mission & Vision */}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -122,7 +122,7 @@ const Footer = () => {
         <div className="border-t border-gray-800 mt-12 pt-8">
           <div className="flex flex-col md:flex-row justify-between items-center">
             <div className="text-gray-400 text-sm mb-4 md:mb-0">
-              © 2024 KisanLink Technologies Pvt. Ltd. All rights reserved.
+              Agros Link Private Limited. All rights reserved.
             </div>
             <div className="flex space-x-6 text-sm">
               <a href="#" className="text-gray-400 hover:text-white transition-colors">Privacy Policy</a>


### PR DESCRIPTION
Added agros link private limited in footer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added company registration information (COI: U01110TG2022PTC160565) to the About section, appearing immediately after the About Us description for clearer organizational details.
  * Updated footer branding to display “Agros Link Private Limited” in the bottom-right area, ensuring consistent company naming across the site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->